### PR TITLE
Fix #25 Migrate to FastAPI

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -1,0 +1,27 @@
+from portfolioserver.db import init_db_from_cas_file
+import click
+import cutie
+import os
+import sys
+
+CAS_FILE_PATH = "./cas-portfolio.pdf"
+
+
+@click.group()
+def cli():
+    pass
+
+
+@cli.command("init-db")
+def init_db_command():
+    if not os.path.exists(CAS_FILE_PATH):
+        print(
+            "File not found. Make sure you saved your CAS file as cas-portfolio.pdf in directory root"
+        )
+        sys.exit(0)
+
+    init_db_from_cas_file(CAS_FILE_PATH)
+
+
+if __name__ == "__main__":
+    cli()

--- a/portfolioserver/app.py
+++ b/portfolioserver/app.py
@@ -1,19 +1,13 @@
-from flask import Flask
-from .configs import DevelopmentConfig
-
-defaultConfig = DevelopmentConfig()
+from fastapi import FastAPI
 
 
-def create_app(config=defaultConfig):
-    app = Flask(__name__)
-    app.config.from_object(config)
+def create_app():
+    app = FastAPI()
 
-    from . import db
     from . import portfolio
     from . import schemes
 
-    db.init_app(app)
-    app.register_blueprint(portfolio.bp)
-    app.register_blueprint(schemes.bp)
+    app.include_router(portfolio.router)
+    app.include_router(schemes.router)
 
     return app

--- a/portfolioserver/db.py
+++ b/portfolioserver/db.py
@@ -7,8 +7,16 @@ import cutie
 import os
 import sys
 
-config = DevelopmentConfig()
-mongo = MongoClient(config.MONGO_URI, type_registry=get_type_registry())
+
+def get_mongo_client(config=None):
+    if config is None:
+        config = DevelopmentConfig()
+
+    mongo = MongoClient(config.MONGO_URI, type_registry=get_type_registry())
+    return mongo
+
+
+mongo = get_mongo_client()
 
 
 def get_db():

--- a/portfolioserver/db.py
+++ b/portfolioserver/db.py
@@ -1,37 +1,23 @@
-from flask.cli import with_appcontext
-from flask_pymongo import PyMongo
-from flask import current_app
+from pymongo import MongoClient
 from pyportfolio import Portfolio
+from .configs import DevelopmentConfig
 from .codec_options import get_type_registry
 import click
 import cutie
 import os
 import sys
 
-CAS_FILE_PATH = "./cas-portfolio.pdf"
-mongo = PyMongo()
+config = DevelopmentConfig()
+mongo = MongoClient(config.MONGO_URI, type_registry=get_type_registry())
 
 
 def get_db():
-    return mongo.db
+    return mongo.get_default_database()
 
 
-def init_app(app):
-    mongo.init_app(app, type_registry=get_type_registry())
-    app.cli.add_command(init_db_command)
-
-
-@click.command("init-db")
-@with_appcontext
-def init_db_command():
-    if not os.path.exists(CAS_FILE_PATH):
-        print(
-            "File not found. Make sure you saved your CAS file as cas-portfolio.pdf in directory root"
-        )
-        sys.exit(0)
-
+def init_db_from_cas_file(cas_file_path):
     password = cutie.secure_input("Please enter the pdf password:")
-    p = Portfolio(CAS_FILE_PATH, password)
+    p = Portfolio(cas_file_path, password)
     data = p.to_json()
 
     db = get_db()

--- a/portfolioserver/portfolio.py
+++ b/portfolioserver/portfolio.py
@@ -1,18 +1,18 @@
-from flask import Blueprint, request
+from fastapi import APIRouter, Request
 from .db import get_db
 
-bp = Blueprint("portfolio", __name__, url_prefix="/portfolio")
+router = APIRouter(prefix="/portfolio", tags=["portfolio"])
 
 
-@bp.route("/goals/", methods=["GET"])
+@router.get("/goals/")
 def goals():
     _db = get_db()
     user_goals = _db.user_info.find_one(projection={"goals": 1})
     return user_goals, 200
 
 
-@bp.route("/goals/addgoal", methods=["POST"])
-def addgoal():
+@router.post("/goals/addgoal")
+def addgoal(request: Request):
     data = request.get_json()
     goal = data.get("goal", None)
 
@@ -21,11 +21,11 @@ def addgoal():
         _db.user_info.update_one({"_id": 1}, {"$addToSet": {"goals": goal}})
         return {"isSuccess": True}, 200
 
-    return {"error": "Json payload needs key 'goal'"}, 400
+    return {"error": "Json payloZad needs key 'goal'"}, 400
 
 
-@bp.route("/goals/removegoal", methods=["POST"])
-def removegoal():
+@router.post("/goals/removegoal")
+def removegoal(request: Request):
     data = request.get_json()
     goal = data.get("goal", None)
 

--- a/portfolioserver/portfolio.py
+++ b/portfolioserver/portfolio.py
@@ -1,29 +1,25 @@
-from fastapi import APIRouter, Body
+from fastapi import APIRouter, Body, Depends
 from .db import get_db
 
 router = APIRouter(prefix="/portfolio", tags=["portfolio"])
 
 
 @router.get("/goals/", status_code=200)
-def goals():
-    _db = get_db()
+def goals(_db=Depends(get_db)):
     user_goals = _db.user_info.find_one(projection={"goals": 1})
     return user_goals
 
 
 @router.post("/goals/addgoal", status_code=201)
-def addgoal(goal: str = Body(...)):
+def addgoal(goal: str = Body(...), _db=Depends(get_db)):
     if goal is not None:
-        _db = get_db()
         _db.user_info.update_one({"_id": 1}, {"$addToSet": {"goals": goal}})
         return {"isSuccess": True}
 
 
 @router.post("/goals/removegoal")
-def removegoal(goal: str = Body(...)):
+def removegoal(goal: str = Body(...), _db=Depends(get_db)):
     if goal is not None:
-        _db = get_db()
-
         is_valid_goal = _db.user_info.count_documents({"goals": goal})
 
         if is_valid_goal:

--- a/portfolioserver/portfolio.py
+++ b/portfolioserver/portfolio.py
@@ -1,34 +1,26 @@
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, Body
 from .db import get_db
 
 router = APIRouter(prefix="/portfolio", tags=["portfolio"])
 
 
-@router.get("/goals/")
+@router.get("/goals/", status_code=200)
 def goals():
     _db = get_db()
     user_goals = _db.user_info.find_one(projection={"goals": 1})
-    return user_goals, 200
+    return user_goals
 
 
-@router.post("/goals/addgoal")
-def addgoal(request: Request):
-    data = request.get_json()
-    goal = data.get("goal", None)
-
+@router.post("/goals/addgoal", status_code=201)
+def addgoal(goal: str = Body(...)):
     if goal is not None:
         _db = get_db()
         _db.user_info.update_one({"_id": 1}, {"$addToSet": {"goals": goal}})
-        return {"isSuccess": True}, 200
-
-    return {"error": "Json payloZad needs key 'goal'"}, 400
+        return {"isSuccess": True}
 
 
 @router.post("/goals/removegoal")
-def removegoal(request: Request):
-    data = request.get_json()
-    goal = data.get("goal", None)
-
+def removegoal(goal: str = Body(...)):
     if goal is not None:
         _db = get_db()
 
@@ -40,12 +32,10 @@ def removegoal(request: Request):
             if schemes_with_goal == 0:
                 d = _db.user_info.update_one({"_id": 1}, {"$pull": {"goals": goal}})
                 print(d.modified_count)
-                return {"isSuccess": True}, 200
+                return {"isSuccess": True}
 
             return {
                 "error": "Cannot remove goal. There are schemes which have this goal assigned."
-            }, 500
+            }
 
-        return {"error": "Cannot remove goal. Goal does not exist."}, 500
-
-    return {"error": "Json payload needs key 'goal'"}, 400
+        return {"error": "Cannot remove goal. Goal does not exist."}

--- a/portfolioserver/schemes.py
+++ b/portfolioserver/schemes.py
@@ -9,13 +9,13 @@ def overview(_db=Depends(get_db)):
     _schemes = _db.schemes.find(projection={"_id": False, "transactions": False})
     user_info = _db.user_info.find_one({})
     data = {"user_info": user_info, "schemes": [s for s in _schemes]}
-    return data, 200
+    return data
 
 
 @router.get("/{amfi_id}")
 def scheme_details(amfi_id: str, _db=Depends(get_db)):
-    data = _db.schemes.find_one_or_404({"amfi": amfi_id}, projection={"_id": False})
-    return data, 200
+    data = _db.schemes.find_one({"amfi": amfi_id}, projection={"_id": False})
+    return data
 
 
 @router.post("/{amfi_id}/assigngoal")

--- a/portfolioserver/schemes.py
+++ b/portfolioserver/schemes.py
@@ -1,12 +1,11 @@
-from fastapi import APIRouter, Body
+from fastapi import APIRouter, Body, Depends
 from .db import get_db
 
 router = APIRouter(prefix="/schemes", tags=["schemes"])
 
 
-@router.get("/overview/")
-def overview():
-    _db = get_db()
+@router.get("/overview")
+def overview(_db=Depends(get_db)):
     _schemes = _db.schemes.find(projection={"_id": False, "transactions": False})
     user_info = _db.user_info.find_one({})
     data = {"user_info": user_info, "schemes": [s for s in _schemes]}
@@ -14,15 +13,13 @@ def overview():
 
 
 @router.get("/{amfi_id}")
-def scheme_details(amfi_id: str):
-    _db = get_db()
+def scheme_details(amfi_id: str, _db=Depends(get_db)):
     data = _db.schemes.find_one_or_404({"amfi": amfi_id}, projection={"_id": False})
     return data, 200
 
 
 @router.post("/{amfi_id}/assigngoal")
-async def assigngoal(amfi_id: str, goal: str = Body(...)):
-    _db = get_db()
+async def assigngoal(amfi_id: str, goal: str = Body(...), _db=Depends(get_db)):
     is_valid_scheme = _db.schemes.count_documents({"amfi": amfi_id})
 
     if not is_valid_scheme:

--- a/portfolioserver/schemes.py
+++ b/portfolioserver/schemes.py
@@ -1,10 +1,10 @@
-from flask import Blueprint, request
+from fastapi import APIRouter, Request
 from .db import get_db
 
-bp = Blueprint("schemes", __name__, url_prefix="/schemes")
+router = APIRouter(prefix="/schemes", tags=["schemes"])
 
 
-@bp.route("/overview/", methods=["GET"])
+@router.get("/overview/")
 def overview():
     _db = get_db()
     _schemes = _db.schemes.find(projection={"_id": False, "transactions": False})
@@ -13,15 +13,15 @@ def overview():
     return data, 200
 
 
-@bp.route("/<amfi_id>", methods=["GET"])
-def scheme_details(amfi_id):
+@router.get("/{amfi_id}")
+def scheme_details(amfi_id: str):
     _db = get_db()
     data = _db.schemes.find_one_or_404({"amfi": amfi_id}, projection={"_id": False})
     return data, 200
 
 
-@bp.route("/<amfi_id>/assigngoal", methods=["POST"])
-def assigngoal(amfi_id):
+@router.post("/{amfi_id}/assigngoal")
+def assigngoal(amfi_id: str, request: Request):
     _db = get_db()
     _db.schemes.find_one_or_404({"amfi": amfi_id})
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,28 +1,35 @@
 import pytest
+from pymongo import MongoClient
+from fastapi.testclient import TestClient
 from portfolioserver import create_app
 from portfolioserver.configs import TestingConfig
-from portfolioserver.db import get_db
+from portfolioserver.db import get_db, get_mongo_client
 
 config = TestingConfig()
+mongo_test = get_mongo_client(config)
+
+
+def get_test_db():
+    return mongo_test.get_default_database()
+
+
+app = create_app()
+app.dependency_overrides[get_db] = get_test_db
+test_client = TestClient(app)
 
 
 @pytest.fixture(scope="module")
 def client():
-    app = create_app(config)
-
-    with app.test_client() as test_client:
-        with app.app_context():
-            init_db_for_test()
-        yield test_client
-
+    init_db_for_test()
+    yield test_client
     cleanup_db_after_test()
 
 
 def init_db_for_test():
-    db = get_db()
+    db = get_test_db()
     db.user_info.insert_one({"_id": 1, "name": "Test User", "goals": ["goal1"]})
 
 
 def cleanup_db_after_test():
-    db = get_db()
+    db = get_test_db()
     db.user_info.drop()

--- a/tests/test_portfolio.py
+++ b/tests/test_portfolio.py
@@ -2,5 +2,5 @@ def test_goals_page(client):
     response = client.get("/portfolio/goals/")
     assert response.status_code == 200
 
-    data = response.get_json()
+    data = response.json()
     assert data["goals"] == ["goal1"]


### PR DESCRIPTION
This PR migrates the app from Flask to FastAPI bringing all the goodness of payload validation and swagger UI with it.
Fixes #25. Automatically fixes #19.

- `/docs` now shows the SwaggerUI - bundled along with FastAPI
- We no longer have dependency on Flask or Flask-PyMongo
   -  Remove flask commands (init-db). Now we have a manage.py script as driver.
   - We use MongoClient directly
- Update test configs
  - Use FastAPI dependency overrides
  