### PR TITLE
Add pydantic support for json validation and typing

### DIFF
--- a/portfolioserver/codec_options.py
+++ b/portfolioserver/codec_options.py
@@ -1,11 +1,6 @@
 from decimal import Decimal
 from bson.decimal128 import Decimal128
-from bson.codec_options import TypeCodec
-from bson.codec_options import TypeRegistry
-from bson.codec_options import CodecOptions
-import locale
-
-locale.setlocale(locale.LC_NUMERIC, "en_IN")
+from bson.codec_options import TypeCodec, TypeRegistry
 
 
 class DecimalCodec(TypeCodec):
@@ -15,7 +10,7 @@ class DecimalCodec(TypeCodec):
     We will transform it into the Decimal128 type which it understands
     This will help in accurate aggregation etc in queries
 
-    We will read the data back as a localized string"""
+    We will read the data back as Decimal"""
 
     python_type = Decimal
     bson_type = Decimal128
@@ -24,7 +19,7 @@ class DecimalCodec(TypeCodec):
         return Decimal128(value)
 
     def transform_bson(self, value):
-        return locale.format_string("%.4f", value.to_decimal(), grouping=True)
+        return value.to_decimal()
 
 
 def get_type_registry():

--- a/portfolioserver/db.py
+++ b/portfolioserver/db.py
@@ -2,10 +2,7 @@ from pymongo import MongoClient
 from pyportfolio import Portfolio
 from .configs import DevelopmentConfig
 from .codec_options import get_type_registry
-import click
 import cutie
-import os
-import sys
 
 
 def get_mongo_client(config=None):

--- a/portfolioserver/errors.py
+++ b/portfolioserver/errors.py
@@ -3,5 +3,7 @@ INVALID_SCHEME = "Invalid Scheme. Use a valid scheme id."
 GOAL_NOT_FOUND = "Provided goal is not part of user's goals. Add it first."
 
 # GOAL API Errors
-CANNOT_REMOVE_GOAL_EXISTS_IN_SCHEMA = "Cannot remove goal. There are schemes which have this goal assigned."
+CANNOT_REMOVE_GOAL_EXISTS_IN_SCHEMA = (
+    "Cannot remove goal. There are schemes which have this goal assigned."
+)
 CANNOT_REMOVE_GOAL_NOT_FOUND = "Cannot remove goal. Goal does not exist."

--- a/portfolioserver/errors.py
+++ b/portfolioserver/errors.py
@@ -1,3 +1,7 @@
 # Scheme API Errors
 INVALID_SCHEME = "Invalid Scheme. Use a valid scheme id."
 GOAL_NOT_FOUND = "Provided goal is not part of user's goals. Add it first."
+
+# GOAL API Errors
+CANNOT_REMOVE_GOAL_EXISTS_IN_SCHEMA = "Cannot remove goal. There are schemes which have this goal assigned."
+CANNOT_REMOVE_GOAL_NOT_FOUND = "Cannot remove goal. Goal does not exist."

--- a/portfolioserver/errors.py
+++ b/portfolioserver/errors.py
@@ -1,0 +1,3 @@
+# Scheme API Errors
+INVALID_SCHEME = "Invalid Scheme. Use a valid scheme id."
+GOAL_NOT_FOUND = "Provided goal is not part of user's goals. Add it first."

--- a/portfolioserver/models.py
+++ b/portfolioserver/models.py
@@ -1,0 +1,56 @@
+from datetime import date
+from typing import Optional, List, Union
+from pydantic import BaseModel as PydanticBaseModel
+from decimal import Decimal
+import locale
+
+locale.setlocale(locale.LC_NUMERIC, "en_IN")
+
+class BaseModel(PydanticBaseModel):
+    class Config:
+        json_encoders = {
+            Decimal: lambda x: locale.format_string("%.4f", x, grouping=True)
+        }
+
+class GenericPostResponse(BaseModel):
+    isSuccess: Optional[bool] = False
+    error: Optional[str] = None
+
+class GoalRequest(BaseModel):
+    name: str
+
+class Transaction(BaseModel):
+    date: date
+    description: str
+    amount: Decimal
+    units: Union[Decimal, None]
+    nav: Union[Decimal, None]
+    balance: Union[Decimal, None]
+    type: str
+    dividend_rate: Union[Decimal, None]
+    Days: int
+
+class Scheme(BaseModel):
+    amfi: str
+    name: str
+    units: Decimal
+    nav: Decimal
+    valuation: Decimal
+    type: str
+    subtype: str
+    goal: str
+
+class SchemeWithTransactions(Scheme):
+    transactions: List[Transaction]
+
+class UserInfo(BaseModel):
+    name: str
+    email: str
+    address: str
+    mobile: str
+    valuation: Decimal
+    goals: List[str]
+
+class Portfolio(BaseModel):
+    user_info: UserInfo
+    schemes: List[Scheme]

--- a/portfolioserver/models.py
+++ b/portfolioserver/models.py
@@ -6,18 +6,22 @@ import locale
 
 locale.setlocale(locale.LC_NUMERIC, "en_IN")
 
+
 class BaseModel(PydanticBaseModel):
     class Config:
         json_encoders = {
             Decimal: lambda x: locale.format_string("%.4f", x, grouping=True)
         }
 
+
 class GenericPostResponse(BaseModel):
     isSuccess: Optional[bool] = False
     error: Optional[str] = None
 
+
 class GoalRequest(BaseModel):
     name: str
+
 
 class Transaction(BaseModel):
     date: date
@@ -30,6 +34,7 @@ class Transaction(BaseModel):
     dividend_rate: Union[Decimal, None]
     Days: int
 
+
 class Scheme(BaseModel):
     amfi: str
     name: str
@@ -40,8 +45,10 @@ class Scheme(BaseModel):
     subtype: str
     goal: str
 
+
 class SchemeWithTransactions(Scheme):
     transactions: List[Transaction]
+
 
 class UserInfo(BaseModel):
     name: str
@@ -50,6 +57,7 @@ class UserInfo(BaseModel):
     mobile: str
     valuation: Decimal
     goals: List[str]
+
 
 class Portfolio(BaseModel):
     user_info: UserInfo

--- a/portfolioserver/portfolio.py
+++ b/portfolioserver/portfolio.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, Body, Depends
 from .db import get_db
-from .models import Portfolio
+from .models import GoalRequest, Portfolio, GenericPostResponse
+from .errors import CANNOT_REMOVE_GOAL_EXISTS_IN_SCHEMA, CANNOT_REMOVE_GOAL_NOT_FOUND
 
 router = APIRouter(prefix="/portfolio", tags=["portfolio"])
 
@@ -17,28 +18,23 @@ def goals(_db=Depends(get_db)):
     return user_goals
 
 
-@router.post("/goals/addgoal", status_code=201)
-def addgoal(goal: str = Body(...), _db=Depends(get_db)):
-    if goal is not None:
-        _db.user_info.update_one({"_id": 1}, {"$addToSet": {"goals": goal}})
-        return {"isSuccess": True}
+@router.post("/goals/addgoal", status_code=201, response_model=GenericPostResponse)
+def addgoal(goal: GoalRequest, _db=Depends(get_db)):
+    _db.user_info.update_one({"_id": 1}, {"$addToSet": {"goals": goal.name}})
+    return GenericPostResponse(isSuccess=True)
 
 
-@router.post("/goals/removegoal")
-def removegoal(goal: str = Body(...), _db=Depends(get_db)):
-    if goal is not None:
-        is_valid_goal = _db.user_info.count_documents({"goals": goal})
+@router.post("/goals/removegoal", response_model=GenericPostResponse)
+def removegoal(goal: GoalRequest, _db=Depends(get_db)):
+    is_valid_goal = _db.user_info.count_documents({"goals": goal.name})
 
-        if is_valid_goal:
-            schemes_with_goal = _db.schemes.count_documents({"goal": goal})
+    if is_valid_goal:
+        schemes_with_goal = _db.schemes.count_documents({"goal": goal.name})
 
-            if schemes_with_goal == 0:
-                d = _db.user_info.update_one({"_id": 1}, {"$pull": {"goals": goal}})
-                print(d.modified_count)
-                return {"isSuccess": True}
+        if schemes_with_goal == 0:
+            _db.user_info.update_one({"_id": 1}, {"$pull": {"goals": goal.name}})
+            return GenericPostResponse(isSuccess=True)
 
-            return {
-                "error": "Cannot remove goal. There are schemes which have this goal assigned."
-            }
+        return GenericPostResponse(error=CANNOT_REMOVE_GOAL_EXISTS_IN_SCHEMA)
 
-        return {"error": "Cannot remove goal. Goal does not exist."}
+    return GenericPostResponse(error=CANNOT_REMOVE_GOAL_NOT_FOUND)

--- a/portfolioserver/portfolio.py
+++ b/portfolioserver/portfolio.py
@@ -5,9 +5,12 @@ from .errors import CANNOT_REMOVE_GOAL_EXISTS_IN_SCHEMA, CANNOT_REMOVE_GOAL_NOT_
 
 router = APIRouter(prefix="/portfolio", tags=["portfolio"])
 
+
 @router.get("/overview", response_model=Portfolio)
 def overview(_db=Depends(get_db)):
-    _schemes = [s for s in _db.schemes.find(projection={"_id": False, "transactions": False})]
+    _schemes = [
+        s for s in _db.schemes.find(projection={"_id": False, "transactions": False})
+    ]
     user_info = _db.user_info.find_one({}, projection={"_id": False})
     return Portfolio(user_info=user_info, schemes=_schemes)
 

--- a/portfolioserver/portfolio.py
+++ b/portfolioserver/portfolio.py
@@ -1,7 +1,14 @@
 from fastapi import APIRouter, Body, Depends
 from .db import get_db
+from .models import Portfolio
 
 router = APIRouter(prefix="/portfolio", tags=["portfolio"])
+
+@router.get("/overview", response_model=Portfolio)
+def overview(_db=Depends(get_db)):
+    _schemes = [s for s in _db.schemes.find(projection={"_id": False, "transactions": False})]
+    user_info = _db.user_info.find_one({}, projection={"_id": False})
+    return Portfolio(user_info=user_info, schemes=_schemes)
 
 
 @router.get("/goals/", status_code=200)

--- a/portfolioserver/schemes.py
+++ b/portfolioserver/schemes.py
@@ -5,11 +5,12 @@ from .errors import INVALID_SCHEME, GOAL_NOT_FOUND
 
 router = APIRouter(prefix="/schemes", tags=["schemes"])
 
+
 @router.get("/{amfi_id}/details", response_model=SchemeWithTransactions)
 def scheme_details(amfi_id: str, _db=Depends(get_db)):
     data = _db.schemes.find_one({"amfi": amfi_id}, projection={"_id": False})
     if not data:
-        raise HTTPException(status_code=404, detail=INVALID_SCHEME) 
+        raise HTTPException(status_code=404, detail=INVALID_SCHEME)
     return data
 
 
@@ -18,7 +19,7 @@ async def assign_goal(amfi_id: str, goal: GoalRequest, _db=Depends(get_db)):
     is_valid_scheme = _db.schemes.count_documents({"amfi": amfi_id})
 
     if not is_valid_scheme:
-        raise HTTPException(status_code=404, detail=INVALID_SCHEME) 
+        raise HTTPException(status_code=404, detail=INVALID_SCHEME)
 
     is_valid_goal = _db.user_info.count_documents({"goals": goal.name})
 

--- a/portfolioserver/schemes.py
+++ b/portfolioserver/schemes.py
@@ -1,19 +1,11 @@
 from fastapi import APIRouter, Depends, HTTPException
 from .db import get_db
-from .models import GoalRequest, GenericPostResponse, SchemeWithTransactions, Portfolio
+from .models import GoalRequest, GenericPostResponse, SchemeWithTransactions
 from .errors import INVALID_SCHEME, GOAL_NOT_FOUND
 
 router = APIRouter(prefix="/schemes", tags=["schemes"])
 
-
-@router.get("/overview", response_model=Portfolio)
-def overview(_db=Depends(get_db)):
-    _schemes = [s for s in _db.schemes.find(projection={"_id": False, "transactions": False})]
-    user_info = _db.user_info.find_one({}, projection={"_id": False})
-    return Portfolio(user_info=user_info, schemes=_schemes)
-
-
-@router.get("/{amfi_id}", response_model=SchemeWithTransactions)
+@router.get("/{amfi_id}/details", response_model=SchemeWithTransactions)
 def scheme_details(amfi_id: str, _db=Depends(get_db)):
     data = _db.schemes.find_one({"amfi": amfi_id}, projection={"_id": False})
     if not data:

--- a/portfolioserver/schemes.py
+++ b/portfolioserver/schemes.py
@@ -1,37 +1,37 @@
-from fastapi import APIRouter, Body, Depends
+from fastapi import APIRouter, Depends, HTTPException
 from .db import get_db
+from .models import GoalRequest, GenericPostResponse, SchemeWithTransactions, Portfolio
+from .errors import INVALID_SCHEME, GOAL_NOT_FOUND
 
 router = APIRouter(prefix="/schemes", tags=["schemes"])
 
 
-@router.get("/overview")
+@router.get("/overview", response_model=Portfolio)
 def overview(_db=Depends(get_db)):
-    _schemes = _db.schemes.find(projection={"_id": False, "transactions": False})
-    user_info = _db.user_info.find_one({})
-    data = {"user_info": user_info, "schemes": [s for s in _schemes]}
-    return data
+    _schemes = [s for s in _db.schemes.find(projection={"_id": False, "transactions": False})]
+    user_info = _db.user_info.find_one({}, projection={"_id": False})
+    return Portfolio(user_info=user_info, schemes=_schemes)
 
 
-@router.get("/{amfi_id}")
+@router.get("/{amfi_id}", response_model=SchemeWithTransactions)
 def scheme_details(amfi_id: str, _db=Depends(get_db)):
     data = _db.schemes.find_one({"amfi": amfi_id}, projection={"_id": False})
+    if not data:
+        raise HTTPException(status_code=404, detail=INVALID_SCHEME) 
     return data
 
 
-@router.post("/{amfi_id}/assigngoal")
-async def assigngoal(amfi_id: str, goal: str = Body(...), _db=Depends(get_db)):
+@router.post("/{amfi_id}/assigngoal", response_model=GenericPostResponse)
+async def assign_goal(amfi_id: str, goal: GoalRequest, _db=Depends(get_db)):
     is_valid_scheme = _db.schemes.count_documents({"amfi": amfi_id})
 
     if not is_valid_scheme:
-        return {"error": "Invalid Scheme"}
+        raise HTTPException(status_code=404, detail=INVALID_SCHEME) 
 
-    if goal is not None:
-        is_valid_goal = _db.user_info.count_documents({"goals": goal})
+    is_valid_goal = _db.user_info.count_documents({"goals": goal.name})
 
-        if is_valid_goal:
-            _db.schemes.update_one({"amfi": amfi_id}, {"$set": {"goal": goal}})
-            return {"isSuccess": True}
+    if is_valid_goal:
+        _db.schemes.update_one({"amfi": amfi_id}, {"$set": {"goal": goal.name}})
+        return GenericPostResponse(isSuccess=True)
 
-        return {"error": "Provided goal is not part of user's goals. Add it first."}
-
-    return {"error": "Json payload needs key 'goal'"}
+    return GenericPostResponse(error=GOAL_NOT_FOUND)


### PR DESCRIPTION
Fixes #18 

## Changes 
 - Update codec to read as Decimal
 - Add pydantic models for schemes API
 - Use models in schemes api
 - Move overview endpoint to portfolio
 - use `/details` for scheme details
 - Remove unnecessary imports in db.py
 - Use models in portfolio apis 