### PR TITLE
Update Decimal encoder

### DIFF
--- a/.github/workflows/pytest-codecov.yml
+++ b/.github/workflows/pytest-codecov.yml
@@ -33,9 +33,6 @@ jobs:
         mongodb-version: ${{ matrix.mongodb-version }}
     - name: Install Dependencies
       run: |
-        sudo locale-gen en_IN.UTF-8
-        export LC_ALL="en_IN"
-        sudo dpkg-reconfigure locales
         git submodule update --init --recursive
         pip install -r requirements.txt
         pip install pytest coverage

--- a/portfolioserver/models.py
+++ b/portfolioserver/models.py
@@ -2,16 +2,20 @@ from datetime import date
 from typing import Optional, List, Union
 from pydantic import BaseModel as PydanticBaseModel
 from decimal import Decimal
-import locale
+from fastapi.encoders import jsonable_encoder
 
-locale.setlocale(locale.LC_NUMERIC, "en_IN")
+
+def decimal_encoder(number: Decimal):
+    """We want to round the decimal to 4 decimal places
+    and return the value with default encoding used by FastAPI
+    """
+    rounded_number = number.quantize(Decimal(".0001"))
+    return jsonable_encoder(rounded_number)
 
 
 class BaseModel(PydanticBaseModel):
     class Config:
-        json_encoders = {
-            Decimal: lambda x: locale.format_string("%.4f", x, grouping=True)
-        }
+        json_encoders = {Decimal: decimal_encoder}
 
 
 class GenericPostResponse(BaseModel):


### PR DESCRIPTION
We now round the decimal to 4 decimal places and perform encoding using FastAPI's `jsonable_encoder`.
This ensures that our return value is a float with precision upto 4 digits. The clients can choose how to render the number as string.