### PR TITLE
Remove pyportfolio submodule, use pypi package

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "pyportfolio"]
-	path = pyportfolio
-	url = https://github.com/kaushiksk/pyportfolio

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ click==7.1.2
 cutie==0.2.2
 fastapi==0.65.1
 pymongo==3.11.4
-./pyportfolio/
+pyportfolio==1.0.0
 uvicorn==0.14.0


### PR DESCRIPTION
`pyportfolio` is now a PyPI package. We no longer need to use it as submodule.