### PR TITLE
Bug Fixes: package conflicts

### DIFF
--- a/portfolioserver/db/core.py
+++ b/portfolioserver/db/core.py
@@ -28,7 +28,7 @@ def get_db() -> Database:
 def init_db_from_cas_file(cas_file_path, goals_file=None):
     password = cutie.secure_input("Please enter the pdf password:")
     p = Portfolio(cas_file_path, password)
-    data = p.to_json()
+    data = p.to_dict()
 
     data["user_info"]["valuation"] = data["valuation"]
     data["user_info"]["_id"] = 1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 aiofiles==0.7.0
-click==7.1.2
+click
 cutie==0.2.2
 fastapi==0.65.1
 pymongo==3.11.4


### PR DESCRIPTION
- pyportfolio already specifies a required version for click, hence removing it from our requirements so that pip can figure this out itself
- With the latest version, `Portfolio` exposes the `to_dict` method. Updated accordingly.